### PR TITLE
Upgrade Python version to 3.13 in Dockerfile

### DIFF
--- a/src/jupyter-snowpark/dockerfile
+++ b/src/jupyter-snowpark/dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.13
 LABEL author=""
 
 #Install packages & python base


### PR DESCRIPTION
python 3.9 is EOL as per <https://docs.snowflake.com/en/developer-guide/python-runtime-support-policy> and results in an error/warning message when following the Quickstart guide.

<img width="2988" height="884" alt="image" src="https://github.com/user-attachments/assets/c84f2c4d-c293-438c-919c-8725e488c44c" />
